### PR TITLE
add: feature to remotely set the main brightness fader

### DIFF
--- a/src/control_desk/bank_column.cpp
+++ b/src/control_desk/bank_column.cpp
@@ -17,9 +17,20 @@ COMPILER_RESTORE("-Wuseless-cast")
 
 namespace dmxfish::control_desk {
 
-	bank_column::bank_column(std::weak_ptr<device_handle> device_connection, std::function<void(std::string const&, bool)> _desk_ready_update, std::function<void(std::string const&, bool)> _select_state_handler, bank_mode mode, std::string _id, uint8_t column_index) :
-		connection(device_connection), desk_ready_update(_desk_ready_update), select_state_handler(_select_state_handler), id(_id), display_text_up{}, display_text_down{}, color{}, readymode_color{}, raw_configuration{},
-		readymode_raw_configuration{}, current_bank_mode(mode), fader_index(column_index) {
+	bank_column::bank_column(
+            std::weak_ptr<device_handle> device_connection,
+            std::function<void(std::string const&, bool)> _desk_ready_update,
+            std::function<void(std::string const&, bool)> _select_state_handler,
+            bank_mode mode, std::string _id, uint8_t column_index
+            ) :
+		connection(device_connection),
+        desk_ready_update(_desk_ready_update),
+        select_state_handler(_select_state_handler),
+        id(_id), display_text_up{}, display_text_down{},
+        color{}, readymode_color{}, raw_configuration{},
+		readymode_raw_configuration{},
+        current_bank_mode(mode),
+        fader_index(column_index) {
 			display_text_up.emplace_back("");
 			display_text_down.emplace_back("");
 		}

--- a/src/control_desk/desk.cpp
+++ b/src/control_desk/desk.cpp
@@ -566,20 +566,20 @@ namespace dmxfish::control_desk {
     }
 
     void desk::update_fader_position_from_protobuf(const ::missiondmx::fish::ipcmessages::fader_position& msg) {
+        const auto& cid = msg.column_id();
+        if(cid == "main") {
+            this->global_illumination = msg.position();
+            for (auto d : this->devices) {
+                if (d->get_device_id() == midi_device_id::X_TOUCH) {
+                    xtouch_set_fader_position(*d, fader::FADER_MAIN, msg.position() * 127 / 65536);
+                }
+            }
+            return;
+        }
         if(!(current_active_bank_set < bank_sets.size())) {
             return;
         }
         auto& bs = bank_sets[current_active_bank_set];
-        const auto& cid = msg.column_id();
-	if(cid == "main") {
-		this->global_illumination = msg.position();
-		for (auto d : this->devices) {
-			if (d->get_device_id() == midi_device_id::X_TOUCH) {
-				xtouch_set_fader_position(*d, fader::FADER_MAIN, msg.position() * 128 / 65536);
-			}
-		}
-		return;
-	}
         if(!bs.columns_map.contains(cid)) {
             return;
         }

--- a/src/control_desk/desk.cpp
+++ b/src/control_desk/desk.cpp
@@ -571,6 +571,15 @@ namespace dmxfish::control_desk {
         }
         auto& bs = bank_sets[current_active_bank_set];
         const auto& cid = msg.column_id();
+	if(cid == "main") {
+		this->global_illumination = msg.position();
+		for (auto d : this->devices) {
+			if (d->get_device_id() == midi_device_id::X_TOUCH) {
+				xtouch_set_fader_position(*d, fader::FADER_MAIN, msg.position() * 128 / 65536);
+			}
+		}
+		return;
+	}
         if(!bs.columns_map.contains(cid)) {
             return;
         }


### PR DESCRIPTION
There is still a bug, causing the update to be dropped if there is no active bank set.