### PR TITLE
segv stack printer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,31 @@
+#include <execinfo.h>
+#include <signal.h>
+
 #include "lib/logging.hpp"
 #include "lib/macros.hpp"
 
 int main_loop();
 
+void segv_handler(int sig) {
+    // unfortunately this needs to be plain C
+    void *bt_array[10];
+    size_t size;
+
+    // get void*'s for all entries on the stack
+    size = backtrace(bt_array, 10);
+
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d, handled with base exception handler:\n", sig);
+    backtrace_symbols_fd(bt_array, size, STDERR_FILENO);
+    exit(1);
+}
+
 int main(int argc, char* argv[], char* env[]) {
 	MARK_UNUSED(argc);
 	MARK_UNUSED(argv);
 	MARK_UNUSED(env);
+
+    signal(SIGSEGV, segv_handler);
 
 	spdlog::set_level(spdlog::level::debug);
 


### PR DESCRIPTION
This piece of code should print us a stack trace in case of segmentation faults. This might come in handy while debugging filters.