### PR TITLE
state subsystem

### DIFF
--- a/src/executioners/state_registry.cpp
+++ b/src/executioners/state_registry.cpp
@@ -1,0 +1,18 @@
+//
+// Created by Leon Dietrich on 13.01.25.
+//
+#include "state_registry.hpp"
+
+#include <unordered_map>
+
+namespace dmxfish::execution::state_registry {
+    std::unordered_map<std::string, std::string> scene_specific_map, unspecific_map;
+
+    void set(const size_t scene_id, const std::string& key, const std::string& value) {
+        scene_specific_map[std::to_string(scene_id) + "::" + key] = value;
+    }
+
+    void set(const std::string& key, const std::string& value) {
+        unspecific_map[key] = value;
+    }
+}

--- a/src/executioners/state_registry.cpp
+++ b/src/executioners/state_registry.cpp
@@ -15,4 +15,19 @@ namespace dmxfish::execution::state_registry {
     void set(const std::string& key, const std::string& value) {
         unspecific_map[key] = value;
     }
+
+    [[nodiscard]] std::optional<std::string> get(const std::string& key) {
+        if (!unspecific_map.contains(key)) {
+            return std::nullopt;
+        }
+        return unspecific_map.at(key);
+    }
+
+    [[nodiscard]] std::optional<std::string> get(const size_t scene_id, const std::string& key) {
+        const auto akey = std::to_string(scene_id) + "::" + key;
+        if (!unspecific_map.contains(akey)) {
+            return std::nullopt;
+        }
+        return unspecific_map.at(akey);
+    }
 }

--- a/src/executioners/state_registry.cpp
+++ b/src/executioners/state_registry.cpp
@@ -65,4 +65,9 @@ namespace dmxfish::execution::state_registry {
 	}
 	return !was_empty;
     }
+
+    void reset_state_registry() {
+        unspecific_map.clear();
+        scene_specific_map.clear();
+    }
 }

--- a/src/executioners/state_registry.cpp
+++ b/src/executioners/state_registry.cpp
@@ -6,6 +6,8 @@
 #include <cstdlib>
 #include <unordered_map>
 
+#include "lib/logging.hpp"
+
 namespace dmxfish::execution::state_registry {
     std::unordered_map<std::string, std::string> scene_specific_map, unspecific_map;
 
@@ -26,10 +28,10 @@ namespace dmxfish::execution::state_registry {
 
     [[nodiscard]] std::optional<std::string> get(const size_t scene_id, const std::string& key) {
         const auto akey = std::to_string(scene_id) + "::" + key;
-        if (!unspecific_map.contains(akey)) {
+        if (!scene_specific_map.contains(akey)) {
             return std::nullopt;
         }
-        return unspecific_map.at(akey);
+        return scene_specific_map.at(akey);
     }
 
     [[nodiscard]] bool update_states_from_message(::missiondmx::fish::ipcmessages::state_list& msg) {
@@ -63,11 +65,22 @@ namespace dmxfish::execution::state_registry {
             kvs->set_v(v);
 	    }
 	}
-	return !was_empty;
+	return was_empty;
     }
 
     void reset_state_registry() {
         unspecific_map.clear();
         scene_specific_map.clear();
+    }
+
+    void dump_state_to_logging() {
+        ::spdlog::debug("Unspecific states:");
+        for (auto& [k, v]: unspecific_map) {
+            ::spdlog::debug("{} = {}", k, v);
+        }
+        ::spdlog::debug("Specific states:");
+        for (auto& [k, v]: scene_specific_map) {
+            ::spdlog::debug("{} = {}", k, v);
+        }
     }
 }

--- a/src/executioners/state_registry.cpp
+++ b/src/executioners/state_registry.cpp
@@ -30,4 +30,27 @@ namespace dmxfish::execution::state_registry {
         }
         return unspecific_map.at(akey);
     }
+
+    [[nodiscard]] bool update_states_from_message(::missiondmx::fish::ipcmessages::state_list& msg) {
+	bool was_empty = true;
+	for (const auto& [k, v] : msg.unspecific_states()) {
+	    was_empty = false;
+	    unspecific_map[k] = v;
+	}
+	for (const auto& kvs : msg.specific_states()) {
+	    was_empty = false;
+	    set(kvs.scene_id(), kvs.k(), kvs.v());
+	}
+	if(was_empty) {
+	    for(const auto& [k, v] : unspecific_map) {
+		msg.unspecific_states().Add(k, v);
+	    }
+	    for(const auto& [sk, v]: scene_specific_map) {
+		// TODO split
+		// TODO store in message
+		// TODO insert message
+	    }
+	}
+	return !was_empty;
+    }
 }

--- a/src/executioners/state_registry.hpp
+++ b/src/executioners/state_registry.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <optional>
+#include "proto_src/RealTimeControl.pb.h"
 
 namespace dmxfish::execution::state_registry {
 
@@ -44,5 +45,12 @@ namespace dmxfish::execution::state_registry {
      */
     void set(const size_t scene_id, const std::string& key, const std::string& value);
 
-    // TODO write serialization method to protobuf
+    /**
+     * This method updates the state registry if the provided message is not empty.
+     * Otherwise it will fill it with the current state.
+     *
+     * @param msg The message to handle or fill
+     * @return True if the message was filled and needs to be transmitted.
+     */
+    [[nodiscard]] bool update_states_from_message(::missiondmx::fish::ipcmessages::state_list& msg);
 }

--- a/src/executioners/state_registry.hpp
+++ b/src/executioners/state_registry.hpp
@@ -53,4 +53,9 @@ namespace dmxfish::execution::state_registry {
      * @return True if the message was filled and needs to be transmitted.
      */
     [[nodiscard]] bool update_states_from_message(::missiondmx::fish::ipcmessages::state_list& msg);
+
+    /**
+     * This method purges all states from existence.
+     */
+    void reset_state_registry();
 }

--- a/src/executioners/state_registry.hpp
+++ b/src/executioners/state_registry.hpp
@@ -58,4 +58,9 @@ namespace dmxfish::execution::state_registry {
      * This method purges all states from existence.
      */
     void reset_state_registry();
+
+    /**
+     * This method may be called for debugging purposes to dump all states to stdout.
+     */
+    void dump_state_to_logging();
 }

--- a/src/executioners/state_registry.hpp
+++ b/src/executioners/state_registry.hpp
@@ -1,0 +1,48 @@
+//
+// Created by Leon Dietrich on 13.01.25.
+//
+
+#pragma once
+
+#include <string>
+#include <optional>
+
+namespace dmxfish::execution::state_registry {
+
+    /**
+     * This method returns the value associated with that key.
+     *
+     * @param key The key of the value to fetch
+     * @return The value associated if available
+     */
+    [[nodiscard]] std::optional<std::string> get(const std::string& key);
+
+    /**
+     * This method returns the value associated with that key inside the specified
+     * scene id.
+     *
+     * @param scene_id The id of the scene the parameter belongs to
+     * @param key The key of the parameter. This might be in the form filterid::parameter
+     * @return The value (if any)
+     */
+    [[nodiscard]] std::optional<std::string> get(const size_t scene_id, const std::string& key);
+
+    /**
+     * Use this method to set a key to a value.
+     *
+     * @param key The key to update the value from
+     * @param value The value to set
+     */
+    void set(const std::string& key, const std::string& value);
+
+    /**
+     * Use this method in order to set a value belonging to a key of a specified scene
+     *
+     * @param scene_id The ID of the scene
+     * @param key The key to update
+     * @param value The value to set
+     */
+    void set(const size_t scene_id, const std::string& key, const std::string& value);
+
+    // TODO write serialization method to protobuf
+}

--- a/src/io/iomanager.cpp
+++ b/src/io/iomanager.cpp
@@ -517,7 +517,7 @@ void IOManager::parse_message_cb(uint32_t msg_type, client_handler& client){
 	case ::missiondmx::fish::ipcmessages::MSGT_STATE_LIST: {
             auto msg = ::missiondmx::fish::ipcmessages::state_list();
 	    if (msg.ParseFromZeroCopyStream(buffer)) {
-		if (::dmxfish::executioners::state_registry::update_states_from_message(msg)) {
+		if (::dmxfish::execution::state_registry::update_states_from_message(msg)) {
 		    client.write_message(msg, ::missiondmx::fish::ipcmessages::MSGT_STATE_LIST);
 		}
 	    } else {

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -1,0 +1,60 @@
+//
+// Created by Leon Dietrich on 20.01.25.
+//
+#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MODULE FISH_TESTS
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <sstream>
+
+#include "executioners/state_registry.hpp"
+
+BOOST_AUTO_TEST_CASE(get_and_set_states) {
+    using namespace dmxfish::execution::state_registry;
+    set("TestKey123", "abc");
+    auto reply = get("TestKey456");
+    BOOST_CHECK_EQUAL(reply.has_value(), false);
+    reply = get("TestKey123");
+    BOOST_CHECK_EQUAL(reply.value(), "abc");
+
+    set(1, "TestKey123", "def");
+    reply = get(1, "TestKey456");
+    BOOST_CHECK_EQUAL(reply.has_value(), false);
+    reply = get(1, "TestKey123");
+    BOOST_CHECK_EQUAL(reply.value(), "def");
+    reply = get(0, "TestKey123");
+    BOOST_CHECK_EQUAL(reply.has_value(), false);
+}
+
+BOOST_AUTO_TEST_CASE(return_states_on_empty_message) {
+    using namespace dmxfish::execution::state_registry;
+    using namespace missiondmx::fish::ipcmessages;
+    reset_state_registry();
+    set("MSG1TestKeyA", "abc1");
+    set(1, "MSG1TestKey", "def1");
+    state_list msg;
+    BOOST_CHECK_EQUAL(update_states_from_message(msg), false);
+    auto item_count = 0;
+    for(auto& [k,v] : msg.unspecific_states()) {
+        BOOST_CHECK_EQUAL(k, "MSG1TestKeyA");
+        BOOST_CHECK_EQUAL(v, "abc1");
+        item_count++;
+    }
+    BOOST_CHECK_EQUAL(item_count, 1);
+    item_count = 0;
+    for(auto& kvs : msg.specific_states()) {
+        item_count++;
+        BOOST_CHECK_EQUAL(kvs.k(), "MSG1TestKey");
+        BOOST_CHECK_EQUAL(kvs.scene_id(), 1);
+        BOOST_CHECK_EQUAL(kvs.v(), "def1");
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(fill_states_on_message) {
+    using namespace dmxfish::execution::state_registry;
+    using namespace missiondmx::fish::ipcmessages;
+    reset_state_registry();
+    // TODO
+}


### PR DESCRIPTION
System to store state between scene updates or across scenes and other filters. For example: the requested feature for seamless scene updates while cues are running requires this in order to have persistent states between updates.