### PR TITLE
cue state persistence feature

### DIFF
--- a/src/executioners/project_configuration.cpp
+++ b/src/executioners/project_configuration.cpp
@@ -39,6 +39,9 @@ bool project_configuration::set_active_scene(unsigned int new_scene) {
 		return false;
 	}
 	const auto new_scene_index = this->scene_id_mapping.at(new_scene);
+    if (new_scene_index == this->current_active_scene) {
+        return false;
+    }
 	if (const auto current_scene = this->get_active_scene(); current_scene < this->scenes.size()) {
 		this->scenes[current_scene].on_stop();
 	}

--- a/src/executioners/scene.hpp
+++ b/src/executioners/scene.hpp
@@ -68,7 +68,11 @@ public:
 	/**
 	 * This method gets called when the scene becomes invisible.
 	 */
-	inline void on_stop() {}
+	inline void on_stop() {
+        for (auto f_ptr : this->filters) {
+            f_ptr->scene_deactivated();
+        }
+    }
 
 	[[nodiscard]] inline size_t get_filter_count() {
 		return this->filters.size();

--- a/src/filters/filter.hpp
+++ b/src/filters/filter.hpp
@@ -100,6 +100,11 @@ public:
 	 */
 	virtual void scene_activated() = 0;
 
+    /**
+     * This method may be used to store any state as it gets called prior to scene switches.
+     */
+    virtual void scene_deactivated() {}
+
 	/**
 	 * This method gets called if the GUI published a parameter update.
 	 * @param key the parameter to change

--- a/src/filters/filter_cue.cpp
+++ b/src/filters/filter_cue.cpp
@@ -852,7 +852,7 @@ namespace dmxfish::filters {
                     update_last_values_from_cuelist();
                     this->actual_values.frame++;
                 }
-                update_last_values_from_cuelist()
+                //update_last_values_from_cuelist() // TODO this is left over from the experiment @LRalff conducted
                 ::spdlog::info("Resumed cue from stored state.");
                 return;
             }

--- a/src/filters/filter_cue.cpp
+++ b/src/filters/filter_cue.cpp
@@ -819,15 +819,21 @@ namespace dmxfish::filters {
             if(auto c_opt = state_registry::get(scene_id, this->own_filter_id + "::cue"); c_opt.has_value()) {
                 this->actual_values.cue = (size_t) std::stol(c_opt.value());
                 loaded_values &= true;
+            } else {
+                loaded_values = false;
             }
             if(auto f_opt = state_registry::get(scene_id, this->own_filter_id + "::frame"); f_opt.has_value()) {
                 this->actual_values.frame = (size_t) std::stol(f_opt.value());
                 loaded_values &= true;
+            } else {
+                loaded_values = false;
             }
             if(auto t_opt = state_registry::get(scene_id, this->own_filter_id + "::time"); t_opt.has_value()) {
                 this->current_time = *(this->time);
-                this->start_time = std::stod(t_opt.value()) + this->current_time;
+                this->start_time = this->current_time - std::stod(t_opt.value());
                 loaded_values &= true;
+            } else {
+                loaded_values = false;
             }
             if (loaded_values) {
                 // TODO is update_last_values() required here?

--- a/src/filters/filter_cue.hpp
+++ b/src/filters/filter_cue.hpp
@@ -32,11 +32,13 @@ namespace dmxfish::filters {
             DO_NOTHING,
             START_FROM_BEGIN
         };
-        enum run_state{
+
+        enum run_state : uint8_t {
             STOP,
             PLAY,
             PAUSE
         };
+
         enum channel_t{
             EIGHT_BIT,
             SIXTEEN_BIT,
@@ -95,6 +97,7 @@ namespace dmxfish::filters {
         double time_scale = 1;
         double current_time = 0;
         bool scale_valid = true;
+        bool state_persistent = false;
         double start_time = 0;
         double pause_time = 0;
         frame_actual last_values = frame_actual();
@@ -229,6 +232,8 @@ namespace dmxfish::filters {
         virtual void update() override;
 
         virtual void scene_activated() override;
+
+        virtual void scene_deactivated() override;
 
     };
 

--- a/src/filters/filter_time.hpp
+++ b/src/filters/filter_time.hpp
@@ -45,7 +45,11 @@ namespace dmxfish::filters {
             this->now = (double) (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()-get_start_time())).count();
         }
 
-        virtual void scene_activated() override {}
+        virtual void scene_activated() override {
+            // As there are filters requiring the the current time as soon as the scene gets activated,
+            // we need to perform the update here.
+            this->update();
+        }
 
     };
 


### PR DESCRIPTION
This pull request implements a feature enabling state persistance across scene updates.
It works by storing the current state if the configuration parameter `persistence` is activated.

@maxkaussow Should we implement a gui update key for this in order to make it selectable on run time? At the moment, a cue will be resumed both on show file updates as well as switching back from scenes.

@LRahlff Line 833 contains a TODO. Do we need to call that function there or is this only required for resets?