### PR TITLE
add: sum filters

### DIFF
--- a/src/executioners/scene_factory.cpp
+++ b/src/executioners/scene_factory.cpp
@@ -263,6 +263,15 @@ COMPILER_RESTORE("-Weffc++")
                 case filter_type::filter_map_8bit_to_16bit:
                     sum += sizeof(filter_map_8bit_to_16bit);
                     break;
+                case filter_type::filter_sum_8bit:
+                    sum += sizeof(filter_sum_8bit);
+                    break;
+                case filter_type::filter_sum_16bit:
+                    sum += sizeof(filter_sum_16bit);
+                    break;
+                case filter_type::filter_sum_float:
+                    sum += sizeof(filter_sum_float);
+                    break;
 				default: {
 						 std::stringstream ss;
 						 ss << ERROR_FILTER_NOT_IMPLEMENTED_IN_ALLOCATION;
@@ -409,6 +418,12 @@ COMPILER_RESTORE("-Weffc++")
                 return calloc<filter_combine_bytes_to_16bit>(pac);
             case filter_type::filter_map_8bit_to_16bit:
                 return calloc<filter_map_8bit_to_16bit>(pac);
+            case filter_type::filter_sum_8bit:
+                return calloc<filter_sum_8bit>(pac);
+            case filter_type::filter_sum_16bit:
+                return calloc<filter_sum_16bit>(pac);
+            case filter_type::filter_sum_float:
+                return calloc<filter_sum_float>(pac);
 	default:
 		throw scheduling_exception(std::string(ERROR_FILTER_NOT_IMPLEMENTED_IN_CONSTRUCTION) + "Failed to construct filter. The requested filter type (" + std::to_string(type) + ") is not yet implemented.");
 		}

--- a/src/filters/filter_math.hpp
+++ b/src/filters/filter_math.hpp
@@ -154,7 +154,12 @@ namespace dmxfish::filters {
         virtual void update() override {
             this->output = 0;
             for (const auto& v_ptr : this->params) {
-                this->output = std::min(*v_ptr + this->output, std::numeric_limits<T>::max());
+                if constexpr (std::is_same<T, double>::value) {
+                    this->output += *v_ptr;
+                } else {
+                    this->output = (T) std::min((long) *v_ptr + (long) this->output,
+                                                (long) std::numeric_limits<T>::max());
+                }
             }
         }
 

--- a/src/filters/filter_math.hpp
+++ b/src/filters/filter_math.hpp
@@ -4,7 +4,9 @@
  * The filters calculate basic math functions
  */
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 #include <string>
 #include <type_traits>
@@ -152,7 +154,7 @@ namespace dmxfish::filters {
         virtual void update() override {
             this->output = 0;
             for (const auto& v_ptr : this->params) {
-                this->output += *v_ptr;
+                this->output = std::min(*v_ptr + this->output, std::numeric_limits<T>::max());
             }
         }
 

--- a/src/filters/filter_math.hpp
+++ b/src/filters/filter_math.hpp
@@ -5,6 +5,9 @@
  */
 
 #include <cmath>
+#include <vector>
+#include <string>
+#include <type_traits>
 
 #include "filters/filter.hpp"
 #include "lib/macros.hpp"
@@ -98,4 +101,77 @@ namespace dmxfish::filters {
 
     COMPILER_RESTORE("-Weffc++")
 
+    template <typename T, filter_type own_type>
+    class filter_multi_t_sum: public filter {
+    private:
+        COMPILER_SUPRESS("-Weffc++")
+        std::vector<T*> params;
+        COMPILER_RESTORE("-Weffc++")
+        T output = 0;
+    public:
+        filter_multi_t_sum() : filter() {}
+        virtual ~filter_multi_t_sum() {}
+
+        virtual void setup_filter(const std::map<std::string, std::string>& configuration, const std::map<std::string, std::string>& initial_parameters, const channel_mapping& input_channels, const std::string& own_id) override {
+            MARK_UNUSED(initial_parameters);
+            long input_count;
+            if(!configuration.contains("input_count")) [[unlikely]] {
+                throw filter_config_exception("Paramter `item_count` missing.", own_type, own_id);
+            } else {
+                try {
+                    input_count = std::stol(configuration.at("input_count"));
+                    if (input_count < 0) [[unlikely]] {
+                        throw filter_config_exception("`item_count` must not be negative.", own_type, own_id);
+                    }
+                } catch (const std::invalid_argument& e) {
+                    throw filter_config_exception(std::string("Unable to decode `item_count` parameter: ") + e.what(),
+                                                  own_type, own_id);
+                }
+                this->params.reserve();
+            }
+            for (auto i = 0; i < input_count; i++) {
+                const auto key = std::to_string(i);
+                auto& selected_map = get_channel_map(input_channels);
+                if (!selected_map.contains(key)) [[unlikely]] {
+                    throw filter_config_exception("Expected channel input map to contain key: " + key, own_type, own_id);
+                }
+                this->params.push_back(selected_map.at(key));
+            }
+        }
+
+        virtual bool receive_update_from_gui(const std::string& key, const std::string& _value) override {
+            MARK_UNUSED(key);
+            MARK_UNUSED(_value);
+            return false;
+        }
+
+        virtual void get_output_channels(channel_mapping& map, const std::string& name) override {
+            map.float_channels[name + ":value"] = &output;
+        }
+
+        virtual void update() override {
+            this->output = 0;
+            for (const auto& v_ptr : this->params) {
+                this->output += *v_ptr;
+            }
+        }
+
+        virtual void scene_activated() override {}
+    private:
+        constexpr const std::unordered_map<std::string, T>& get_channel_map(const channel_mapping& input_channels) const {
+            if constexpr (std::is_same<T, uint8_t>::value) {
+                return input_channels.eight_bit_channels;
+            } else if constexpr (std::is_same<T, uint16_t>::value) {
+                return input_channels.sixteen_bit_channels;
+            } else if constexpr (std::is_same<T, double>::value) {
+                return input_channels.float_channels;
+            } else {
+                static_assert(false);
+            }
+        }
+    };
+
+    using filter_sum_8bit = filter_multi_t_sum<uint8_t, filter_type::filter_sum_8bit>;
+    using filter_sum_16bit = filter_multi_t_sum<uint16_t, filter_type::filter_sum_16bit>;
+    using filter_sum_float = filter_multi_t_sum<double, filter_type::filter_sum_float>;
 }

--- a/src/filters/filter_math.hpp
+++ b/src/filters/filter_math.hpp
@@ -146,7 +146,7 @@ namespace dmxfish::filters {
         }
 
         virtual void get_output_channels(channel_mapping& map, const std::string& name) override {
-            map.float_channels[name + ":value"] = &output;
+            get_channel_map(map)[name + ":value"] = &output;
         }
 
         virtual void update() override {

--- a/src/filters/types.hpp
+++ b/src/filters/types.hpp
@@ -60,6 +60,9 @@ namespace dmxfish::filters {
         filter_float_map_range_16bit = 55,
         filter_float_map_range_float = 56,
         filter_combine_bytes_to_16bit = 57,
-        filter_map_8bit_to_16bit = 58
+        filter_map_8bit_to_16bit = 58,
+        filter_sum_8bit = 62,
+        filter_sum_16bit = 63,
+        filter_sum_float = 64
     };
 }


### PR DESCRIPTION
This PR adds three filters summing up all inputs. This, together with #91,  is a requirement towards the requested editor feature implementing automatic sum / mixing of multiple inputs to the same input channel.